### PR TITLE
[typo] Fix failed test message

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -22,7 +22,7 @@ envman add --key SNOWPLOW_MICRO_COLLECTOR_RESULTS_BAD --value "$bad"
 
 if [[ $total -eq 0 ]]
 then
-  echo "There are no events posted to Snowplow Micro, text failed."
+  echo "There are no events posted to Snowplow Micro, test failed."
   exit 1
 elif [[ $bad -eq 0 ]]
 then


### PR DESCRIPTION
This PR fixes a typo where no snowplow events are detected. 