### PR TITLE
Not failing the build when there is a bad event

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -33,5 +33,5 @@ else
   # Export the bad json into a file
   curl --silent "$collector_url/micro/bad" | jq '.' >> $BITRISE_DEPLOY_DIR/snowplow_bad.json
 
-  exit 1
+  # exit 1 # Since Remote Snowplow Micro is not stable, we are not going to failed the build when there is bad event. Will comeback to it once it is stable
 fi

--- a/step.sh
+++ b/step.sh
@@ -33,5 +33,12 @@ else
   # Export the bad json into a file
   curl --silent "$collector_url/micro/bad" | jq '.' >> $BITRISE_DEPLOY_DIR/snowplow_bad.json
 
-  # exit 1 # Since the remote Snowplow Micro is not stable, we are not going to fail the build when there is a bad event. I will comeback to it once the server is more stable.
+  if [ "$fail_for_bad_events" = "yes" ]
+  then
+      echo "Failing step because Snowplow reports more than zero bad events ($bad)"
+      exit 1
+  else
+      echo "Found $bad events, but will not fail the step"
+      exit 0
+  fi
 fi

--- a/step.sh
+++ b/step.sh
@@ -33,5 +33,5 @@ else
   # Export the bad json into a file
   curl --silent "$collector_url/micro/bad" | jq '.' >> $BITRISE_DEPLOY_DIR/snowplow_bad.json
 
-  # exit 1 # Since Remote Snowplow Micro is not stable, we are not going to failed the build when there is bad event. Will comeback to it once it is stable
+  # exit 1 # Since the remote Snowplow Micro is not stable, we are not going to fail the build when there is a bad event. I will comeback to it once the server is more stable.
 fi

--- a/step.yml
+++ b/step.yml
@@ -70,6 +70,12 @@ inputs:
       summary: The URL to the Snowplow Micro Collector instance
       is_expand: true
       is_required: true
+  - fail_for_bad_events: "no"
+    opts:
+      title: Fail the step if there are more than zero bad events
+      value_options:
+      - "yes"
+      - "no"
 
 outputs:
   - SNOWPLOW_MICRO_COLLECTOR_RESULTS_TOTAL:


### PR DESCRIPTION
# Why

Failing a QA automation tests some time could cause lots of trouble and debugging from various stakeholders (Developer, QA engineers or others), we need to be careful not causing extra panic 😂 . 

Since remote Snowplow Micro server is not stable, as well as it is open to public access, there will be some random Bad events. This will cause the build to fail, and create disruptions to the people that doesn't have the context of Snowplow Micro event testing. Thanks to @liamnichols mentioned to me, I realise, at this stage, we can avoid failing the build till we have a robust Remote Micro.


> In the grand scheme of things, I wonder if we will want to fail the entire build for bad events :thinkspin: Maybe in the long-run, when things are stable.. But if we anticipate lots of change over the next few months, then maybe we should avoid failing the build for the time being.
We could update the check-collector step to add a “Fail build” flag or something that will decide if > 0 bad == exit 1 if we decide to do that

# How

Simplify comment out the exit when there are more than 0 bad events. 

Subsequently, after merging this PR I will create tag 0.0.2