### PR TITLE
Improve error handling and output a summary message

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,7 +2,7 @@
 
 # Helper for finishing and exiting.
 #   $0 - A summary message to be printed and exported
-#   $1 - The script exit code. Defaults to 0, will be overwritten if $fail_for_bad_events is set to 'no'
+#   $1 - The script exit code. Defaults to 0, will be overwritten if $fail_on_error is set to 'no'
 finish () {
   summary="$1"
   exit_code="$2"
@@ -10,8 +10,8 @@ finish () {
   # Set the summary as an output for use in future steps
   envman add --key SNOWPLOW_MICRO_COLLECTOR_SUMMARY --value "$summary"
 
-  # Downgrade any errors if fail_for_bad_events is turned off
-  if [ "$fail_for_bad_events" = "no" ]
+  # Downgrade any errors if fail_on_error is turned off
+  if [ "$fail_on_error" = "no" ]
   then
     unset exit_code
   fi

--- a/step.sh
+++ b/step.sh
@@ -1,16 +1,39 @@
 #!/bin/bash
-set -e
+
+# Helper for finishing and exiting.
+#   $0 - A summary message to be printed and exported
+#   $1 - The script exit code. Defaults to 0, will be overwritten if $fail_for_bad_events is set to 'no'
+finish () {
+  summary="$1"
+  exit_code="$2"
+
+  # Downgrade any errors if fail_for_bad_events is turned off
+  if [ "$fail_for_bad_events" = "no" ]
+  then
+    unset exit_code
+  fi
+
+  # Finish and exit with the appropriate code
+  echo "$summary"
+  exit "${exit_code:-0}"
+}
 
 echo "Checking status of collector at $collector_url..."
-result=$(curl --silent "$collector_url/micro/all")
+result=$(curl "$collector_url/micro/all")
+echo "Response from the server: '$result'"
 
 # Parse the results
 total=$(jq -r '.total' <<< "$result")
 good=$(jq -r '.good' <<< "$result")
 bad=$(jq -r '.bad' <<< "$result")
 
+# Check that the results were parsed properly
+if [[ -z "$total" ]] || [[ -z "$good" ]] || [[ -z "$bad" ]]
+then
+  finish "Unable to retrieve status from the collector" 1
+fi
+
 # Export them to variables
-echo "Parsed results (total: $total, good: $good, bad: $bad)"
 envman add --key SNOWPLOW_MICRO_COLLECTOR_RESULTS_TOTAL --value "$total"
 envman add --key SNOWPLOW_MICRO_COLLECTOR_RESULTS_GOOD --value "$good"
 envman add --key SNOWPLOW_MICRO_COLLECTOR_RESULTS_BAD --value "$bad"
@@ -20,25 +43,20 @@ envman add --key SNOWPLOW_MICRO_COLLECTOR_RESULTS_BAD --value "$bad"
 # Then create a junit report file that lists each issue as a failure, write it to $BITRISE_TEST_RESULT_DIR
 # It will be sharable script codes among other clients like `Android` and `Web`
 
+# After parsing, use the counts as the output summary
+summary="$bad bad, $good good ($total total)"
+
+# Check the result and finish appropriately
 if [[ $total -eq 0 ]]
 then
-  echo "There are no events posted to Snowplow Micro, test failed."
-  exit 1
+  echo "No events were received by the collector"
+  finish "$summary" 1
 elif [[ $bad -eq 0 ]]
 then
-  echo "Snowplow test was successful 🎉"
+  echo "No bad events were reported by the collector 🎉"
+  finish "$summary" 0
 else
-  echo "Failing step because Snowplow reports more than zero bad events ($bad)"
-  
-  # Export the bad json into a file
+  echo "The collector reported $bad bad events, exporting details to snowplow_bad.json."
   curl --silent "$collector_url/micro/bad" | jq '.' >> $BITRISE_DEPLOY_DIR/snowplow_bad.json
-
-  if [ "$fail_for_bad_events" = "yes" ]
-  then
-      echo "Failing step because Snowplow reports more than zero bad events ($bad)"
-      exit 1
-  else
-      echo "Found $bad events, but will not fail the step"
-      exit 0
-  fi
+  finish "$summary" 1
 fi

--- a/step.sh
+++ b/step.sh
@@ -7,6 +7,9 @@ finish () {
   summary="$1"
   exit_code="$2"
 
+  # Set the summary as an output for use in future steps
+  envman add --key SNOWPLOW_MICRO_COLLECTOR_SUMMARY --value "$summary"
+
   # Downgrade any errors if fail_for_bad_events is turned off
   if [ "$fail_for_bad_events" = "no" ]
   then

--- a/step.sh
+++ b/step.sh
@@ -60,6 +60,6 @@ then
   finish "$summary" 0
 else
   echo "The collector reported $bad bad events, exporting details to snowplow_bad.json."
-  curl --silent "$collector_url/micro/bad" | jq '.' >> $BITRISE_DEPLOY_DIR/snowplow_bad.json
+  curl --silent "$collector_url/micro/bad" | jq '.' >> "$BITRISE_DEPLOY_DIR/snowplow_bad.json"
   finish "$summary" 1
 fi

--- a/step.yml
+++ b/step.yml
@@ -70,9 +70,9 @@ inputs:
       summary: The URL to the Snowplow Micro Collector instance
       is_expand: true
       is_required: true
-  - fail_for_bad_events: "no"
+  - fail_on_error: "no"
     opts:
-      title: Fail the step if there are more than zero bad events
+      title: Fail the step if it is unable to check the results or if there are bad events
       value_options:
       - "yes"
       - "no"

--- a/step.yml
+++ b/step.yml
@@ -90,3 +90,7 @@ outputs:
     opts:
       title: "Good events count"
       summary: Snowplow collector has validated this amount of good events
+  - SNOWPLOW_MICRO_COLLECTOR_SUMMARY:
+    opts:
+      title: Operation Summary
+      summary: A message that can be used to give a summary of the step


### PR DESCRIPTION
# Background 

- https://github.com/cookpad/global-data-platform/issues/676

While we are using the nightly E2E test runs to check the Snowplow collector state, we need to be careful that issues that arise when checking the collector do not interfere with the reporting of the overall E2E test run, especially now while things are under development. 

Currently, when the Check Collector step runs, if we can't reach the instance for whatever reason the experience is a less than desirable for a couple of reasons:

1. The message output in Slack is missing counts so it looks a little odd
2. The overall build on Bitrise will fail, which can be confusing for other teams

Ideally we want to be able to minimise the disruption here if possible.

# Changes

These changes go hand in hand with other changes in cookpad/bitrise-step-snowplow-micro-reset-collector#2 and aim to do the following:

1. We now set a new `SNOWPLOW_MICRO_COLLECTOR_SUMMARY` output with a description both upon success and on any kind of failure.
    - This message can be used in the Slack output.
    - Setting it here helps because we don't have to construct it manually (and badly in error scenarios) in both iOS and Android workflows
2. If the `$total`, `$bad` or `$good` variables aren't set (i.e because the `curl` command failed), we no longer will fail the build and instead will exit and set the summary to something else.

To better reflect the changes, I also renamed the `fail_for_bad_events` input to `fail_on_error`.

To test the negative user journeys, you can see this test build here: https://app.bitrise.io/build/54aa8fff-150c-4a60-9dc8-b401ffade251